### PR TITLE
fixes #65 users cannot trade without having an address

### DIFF
--- a/app/controllers/trades/controllers.py
+++ b/app/controllers/trades/controllers.py
@@ -53,6 +53,9 @@ def user_doesnt_already_have_an_active_trade_with_item():
 
 @trade_routes.route('/request/<int:requested_item_id>', methods=['POST'])
 @user_passes_test(test_func=user_doesnt_already_have_an_active_trade_with_item)
+@user_passes_test(test_func=lambda: len(g.user.addresses) > 0,
+                  flashed_message="add an address before trading",
+                  view_path_to_redirect_to='auth.add_address')
 def request_trade(requested_item_id):
     requested_item = Item.query.filter_by(id=requested_item_id).one()
     to_user_id = requested_item.user.id

--- a/app/decorators.py
+++ b/app/decorators.py
@@ -33,14 +33,14 @@ def user_is_logged_in(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         if g.user is None:
-            flash('Must be logged in to access that')
+            flash('Must be logged in to access that', category='warning')
             return redirect(url_for('auth.login', next=request.path))
         return func(*args, **kwargs)
 
     return wrapper
 
 
-def user_passes_test(test_func=lambda: False):
+def user_passes_test(test_func=lambda: False, view_path_to_redirect_to="", flashed_message="", **opts):
     def decorator(func):
         @user_is_logged_in
         @wraps(func)
@@ -48,6 +48,10 @@ def user_passes_test(test_func=lambda: False):
             if test_func():
                 return func(*args, **kwargs)
             else:
+                if view_path_to_redirect_to:
+                    if flashed_message:
+                        flash(flashed_message, category='error')
+                    return redirect(url_for(view_path_to_redirect_to, next=request.path, **opts))
                 abort(403)
         return wrapper
     return decorator

--- a/app/tests/e2e_tests/test_trade_interaction.py
+++ b/app/tests/e2e_tests/test_trade_interaction.py
@@ -141,3 +141,30 @@ class TradeTests(SeleniumTest):
         error = self.client.find_element_by_css_selector('.alert-danger')
 
         self.assertIn('you are not a part of that trade', error.text.lower())
+
+    def test_user_cannot_trade_without_having_an_address(self):
+        # in this setting, a user, mu tries to trade with omega
+        # however mu does not have an address
+        # should throw an error
+        self.omega_creates_an_item()
+
+        # mu freshly registers
+        self.register('mu@email.com', 'mu', 'password')
+
+        # goes to the sheets page
+        self.go_to('sheets')
+
+        # finds omegas sheet music
+        link = self.client.find_element_by_link_text('symphony #5')
+        link.click()
+
+        # sees that they can trade
+        item = self.client.find_element_by_css_selector('.item-stub')
+        trade_link= item.find_element_by_css_selector('.btn-link')
+        trade_link.click()
+
+        # they are taken to the addresses page
+        # where they see an error that says "you must add an address before you start trading!
+        self.assertIn('dashboard', self.client.current_url)
+        self.assertIn('add an address before you start trading',
+                      self.client.find_element_by_css_selector('flashed-messages').text)

--- a/app/tests/test_base.py
+++ b/app/tests/test_base.py
@@ -71,9 +71,15 @@ class SeleniumTest(unittest.TestCase):
     def setUpClass(cls):
         # start the driver
         try:
+            import subprocess
+            driver_directories = ['/usr/local/bin']
+            os.environ.update({'PATH': ':'.join(driver_directories + [os.environ.get('PATH')])})
             cls.client = webdriver.Firefox()
-        except:
-            pass
+
+        except Exception as exc:
+            print("your path is:\n {}".format(sys.path))
+            print("sys path is:\n {}".format(os.environ.get('PATH')))
+            print("could not load selenium webdriver", str(exc), sep='\n')
 
         if cls.client:
             os.environ['APP_SETTINGS'] == 'testing' or os.environ.update(APP_SETTINGS='testing')
@@ -173,15 +179,15 @@ class SeleniumTest(unittest.TestCase):
         client.find_element_by_xpath('//button[@type="submit"]').click()
 
 
-    def register(self, e, n, p):
+    def register(self, new_email, new_username, new_password):
         self.go_to('auth/register')
         email = self.client.find_element_by_id('email')
         username = self.client.find_element_by_id('username')
         password = self.client.find_element_by_id('password')
         check_password = self.client.find_element_by_id('check_password')
-        email.send_keys(e)
-        username.send_keys(n)
-        password.send_keys(p)
-        check_password.send_keys(p)
+        email.send_keys(new_email)
+        username.send_keys(new_username)
+        password.send_keys(new_password)
+        check_password.send_keys(new_password)
         submit = self.client.find_element_by_xpath('//button[@type="submit"]')
         submit.click()

--- a/templates/util.html
+++ b/templates/util.html
@@ -10,37 +10,37 @@
   'notset': 'info',
   'message': 'info',
 }, default_category='info', dismissible=False) -%}
-{% with messages = messages or get_flashed_messages(with_categories=True) -%}
-{% if messages -%} {# don't output anything if there are no messages #}
+    {% with messages = messages or get_flashed_messages(with_categories=True) -%}
+    {% if messages -%} {# don't output anything if there are no messages #}
 
-{% if container -%}
-<!-- begin message block -->
-<div class="container flashed-messages">
-  <div class="row">
-    <div class="col-md-12">
-{% endif -%}
+        {% if container -%}
+            <!-- begin message block -->
+            <div class="container flashed-messages">
+              <div class="row">
+                <div class="col-md-12">
+            {% endif -%}
 
-{% for cat, msg in messages %}
-    <div class="alert alert-{{transform.get(cat.lower(), default_category or cat)}}
-         {% if dismissible %} alert-dismissible{% endif %}" role="alert">
-{% if dismissible %}
-    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-        <span aria-hidden="true">&times;</span>
-    </button>
-{% endif %}
-        {{msg}}
-      </div>
-{%- endfor -%}
+            {% for cat, msg in messages %}
+                <div class="alert alert-{{transform.get(cat.lower(), default_category or cat)}}
+                     {% if dismissible %} alert-dismissible{% endif %}" role="alert">
+            {% if dismissible %}
+                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            {% endif %}
+                    {{msg}}
+                  </div>
+            {%- endfor -%}
 
-{% if container %}
-    </div>
-  </div>
-</div>
-<!-- end message block -->
-{% endif -%}
+            {% if container %}
+                </div>
+              </div>
+            </div>
+            <!-- end message block -->
+        {% endif -%}
 
-{% endif -%}
-{% endwith -%}
+    {% endif -%}
+    {% endwith -%}
 {% endmacro -%}
 
 


### PR DESCRIPTION
the user can be redirected to a correction state with an appropriate warning using the `user_passes_test` decorator.